### PR TITLE
Added Babel Polyfill with core-js to support ES6 on IE11

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,7 @@ module.exports = {
             'material-ui',
             'redux-form-material-ui',
             'scriptjs',
+            'babel-polyfill',
             'whatwg-fetch'
         ],
 


### PR DESCRIPTION
This fix both `Promise is not defined` and `Object doesn't support property or method 'assign'` issues presented with IE11. Since Babel is already used, i added babel-polyfill that already includes core-js into the webpack config file. 

Probably we should open a new issue about the styling on IE11
![screenshot at oct 02 18-35-45](https://cloud.githubusercontent.com/assets/3399236/19023913/f18f5ef8-88cf-11e6-94d2-8cbb34bdfa4b.png)
