### PR TITLE
#19 add redux-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "express": "^4.13.4",
     "express-session": "^1.13.0",
     "isomorphic-fetch": "^2.2.1",
-    "whatwg-fetch": "^1.0.0",
     "material-ui": "^0.15.4",
     "mongoose": "^4.4.7",
     "morgan": "^1.7.0",
@@ -47,10 +46,12 @@
     "redux": "^3.3.1",
     "redux-form": "^6.0.2",
     "redux-form-material-ui": "^4.0.1",
+    "redux-logger": "^2.6.1",
     "redux-thunk": "^2.0.1",
     "rss": "^1.2.1",
     "scriptjs": "^2.5.8",
-    "webpack": "^1.12.14"
+    "webpack": "^1.12.14",
+    "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/src/boot.jsx
+++ b/src/boot.jsx
@@ -8,6 +8,7 @@ import { syncHistoryWithStore, routerReducer, routerMiddleware } from 'react-rou
 import { combineReducers, createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
+import createLogger from 'redux-logger';
 
 import { reducer as formReducer } from 'redux-form';
 
@@ -22,7 +23,14 @@ import AboutPage from './components/about-page';
 injectTapEventPlugin();
 
 // Apply the middleware to the store
-const middleware = routerMiddleware(browserHistory);
+const routeMiddleware = routerMiddleware(browserHistory);
+
+const middlewares = [thunkMiddleware, routeMiddleware];
+
+if (process.env.NODE_ENV === 'development') {
+    const loggerMiddleware = createLogger();
+    middlewares.push(loggerMiddleware);
+}
 
 const store = createStore(
     combineReducers({
@@ -30,7 +38,7 @@ const store = createStore(
         routing: routerReducer,
         form: formReducer,
     }),
-    applyMiddleware(thunkMiddleware, middleware)
+    applyMiddleware(...middlewares)
 );
 
 // Create an enhanced history that syncs navigation events with the store


### PR DESCRIPTION
## Background

This PR adds `redux-logger` when running in development mode. I thought about moving the process of creating the middleware into a new file but thought this might be premature optimisation. For now as no information on the issue I've stuck with the redux-logger defaults also.

@kitos let me know what you think. There weren't any tests in this area as of yet, this is fairly rudimentary and that task probably needs to be tackled in a separate issue.

![redux-logger](https://cloud.githubusercontent.com/assets/406799/19036368/65d9fa88-8967-11e6-9ea8-85b50ac83735.gif)


