### PR TITLE
Fix VK Like Button

### DIFF
--- a/src/components/event-page/event-page.jsx
+++ b/src/components/event-page/event-page.jsx
@@ -171,7 +171,7 @@ const EventPage = ({ event }) => (
 
       <Flex mt="3.6rem" justifyContent="space-between" alignItems="flex-end">
         <VK apiId={5360165} options={{ version: 152 }}>
-          <Like options={{ type: 'mini', height: 30 }} />
+          <Like options={{ type: 'mini', height: 30 }} pageId={event.title} />
         </VK>
 
         {event.socialNetworks && (


### PR DESCRIPTION
According to documentation VK Like component require page_id if we need two or more independent likes on single page. So if you are using SPA pageId attribute is require.